### PR TITLE
feat: support custom css modules RegEx

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -95,7 +95,17 @@ export interface CSSModulesOptions {
 
 const cssLangs = `\\.(css|less|sass|scss|styl|stylus|pcss|postcss)($|\\?)`
 const cssLangRE = new RegExp(cssLangs)
-const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
+
+const configFile = path.resolve(process.cwd(), 'vite.config.js');
+
+const userCssModuleRe = configFile.css
+  ? configFile.css.modules
+    ? configFile.css.modules.test
+    : null
+  : null;
+
+const cssModuleRE = userCssModuleRe || new RegExp(`\\.module${cssLangs}`);
+
 const directRequestRE = /(\?|&)direct\b/
 const htmlProxyRE = /(\?|&)html-proxy\b/
 const commonjsProxyRE = /\?commonjs-proxy/


### PR DESCRIPTION
### Clear and concise description of the problem

目前vite仅支持在`xx.module.xx`中实现CSS模块化。

如果专门为这个功能开发一款插件，势必会和`vite`源码中有很多重复内容，而且写的还不一定有尤大好。

很多项目可能采用了[react-css-modules](https://link.juejin.cn/?target=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2Freact-css-modules)方案，这种项目从`webpack`迁移到`vite`时需要手动改css文件，于是很多人看到成本有点高就放弃了`vite`，非常可惜，这是作为`vite`不愿意看到的场景。

现在希望添加一个自定义字段，可以实现自定义**CSS module**的文件匹配规则，让vite的覆盖场景更加全面。


### Suggested solution

为`css.modules`添加一个属性`test`

像这样
```javascript
export default defineConfig({
  css: {
    modules: {
      test: /.(css|less|sass|scss|styl|stylus|pcss|postcss)/
    }
  },
})
```

vite根据匹配规则解析到css文件后就会进入CSS module的逻辑。

### Alternative

_No response_

### Additional context

_No response_

### Validations

- [X] Follow our [Code of Conduct](https://github.com/vitejs/vite/blob/main/CODE_OF_CONDUCT.md)
- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [docs](https://vitejs.dev/guide).
- [X] Check that there isn't already an issue that request the same feature to avoid creating a duplicate.